### PR TITLE
fix: correct pod name and update lints

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.2
+  flutter_lints: ^3.0.1
 
 flutter:
   uses-material-design: true

--- a/ios/get_thumbnail_video.podspec
+++ b/ios/get_thumbnail_video.podspec
@@ -2,7 +2,7 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
 #
 Pod::Spec.new do |s|
-  s.name             = 'video_thumbnail'
+  s.name             = 'get_thumbnail_video'
   s.version          = '0.0.1'
   s.summary          = 'A new flutter plugin project.'
   s.description      = <<-DESC
@@ -22,4 +22,3 @@ A new flutter plugin project.
 
   s.ios.deployment_target = '8.0'
 end
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: get_thumbnail_video
 description: A flutter plugin for creating a thumbnail from a local video file or from a video URL.
-version: 0.6.1
+version: 0.6.1+1
 repository: https://github.com/Alberto-Monteiro/video_thumbnail
 
 environment:
@@ -18,8 +18,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.2
-  lints: ^2.1.1
+  flutter_lints: ^3.0.1
+  lints: ^3.0.0
 
 flutter:
   plugin:


### PR DESCRIPTION
Correct the podfile name and update lints to the same versions we use in the mono repo.